### PR TITLE
[changelog] Fix a NullReferenceException when encountering pull requests with added or removed dependencies.

### DIFF
--- a/changelog/Program.cs
+++ b/changelog/Program.cs
@@ -92,7 +92,13 @@ namespace changelog
 								continue;
 							// skip duplicates (if same revisions are used)
 							if (!list.Contains (diff_url)) {
-								Console.WriteLine ($"* {uri} [{old_sha[0..7]}...{new_sha[0..7]}]({uri}/compare/{old_sha}...{new_sha})");
+								if (string.IsNullOrEmpty (old_sha)) {
+									Console.WriteLine ($"* {uri} [{new_sha[0..7]}]({uri}/commits/{new_sha}) (new dependency)");
+								} else if (string.IsNullOrEmpty (new_sha)) {
+									Console.WriteLine ($"* {uri} [{new_sha[0..7]}]({uri}/commits/{old_sha}) (removed dependency)");
+								} else {
+									Console.WriteLine ($"* {uri} [{old_sha[0..7]}...{new_sha[0..7]}]({uri}/compare/{old_sha}...{new_sha})");
+								}
 								list.Add (diff_url);
 							}
 						}


### PR DESCRIPTION
Example: https://github.com/xamarin/xamarin-macios/pull/15716

Output:

```markdown
[...]
## Level 2
Unhandled exception. System.ArgumentOutOfRangeException: Index and length must refer to a location within the string. (Parameter 'length')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at changelog.Program.ProcessDiff(Stream s) in /Users/rolf/work/dotnet-tools/changelog/Program.cs:line 95
   at changelog.Program.Process() in /Users/rolf/work/dotnet-tools/changelog/Program.cs:line 42
   at changelog.Program.Main(String[] args) in /Users/rolf/work/dotnet-tools/changelog/Program.cs:line 30
   at changelog.Program.<Main>(String[] args)
```

Fixed output:

```markdown
# .net ChangeLog for https://github.com/xamarin/xamarin-macios/pull/15716
## Level 1
* https://github.com/dotnet/installer [f3da421...84d26a0](https://github.com/dotnet/installer/compare/f3da421a6e81382d6d2b25b236697f33e210092c...84d26a070704dc4eb7870f15d44880228bb82cb8)

## Level 2
* https://github.com/dotnet/llvm-project [75e182c](https://github.com/dotnet/llvm-project/commits/75e182c26dbf5d9f8ccca0ac68ee63b0bebb17b8) (new dependency)
* https://github.com/dotnet/arcade [6a638cd...0c027ee](https://github.com/dotnet/arcade/compare/6a638cd0c13962ab2a1943cb1c878be5a41dd82e...0c027eede69ba22bafca9a1955f1e00848655ece)
* https://github.com/dotnet/sourcelink [508c31b...42bee1e](https://github.com/dotnet/sourcelink/compare/508c31bb736f3e6d69b8f47fa9ee38eedd9ce785...42bee1e7ae672add1a19e8f5a74499c15e497b07)
* https://github.com/dotnet/xliff-tasks [8dfdebf...47a504c](https://github.com/dotnet/xliff-tasks/compare/8dfdebfefc8acef481f28edadbf7f75a8d6efde4...47a504cdc72993370f057a11c2a39a7faa3111ad)

Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog
```
